### PR TITLE
Unexpected argument 'augumentation'

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -14,7 +14,7 @@ import random
 
 
 def preprocess_midi(path):
-    return encode_midi(path, augumentation=False)
+    return encode_midi(path)
 #     note_seq = NoteSeq.from_midi_file(path)
 #     note_seq.adjust_time(-note_seq.notes[0].start)
 #     event_seq = EventSeq.from_note_seq(note_seq)


### PR DESCRIPTION
In the preprocessing step, [`encode_midi` is called as follows](https://github.com/jason9693/MusicTransformer-tensorflow2.0/blob/master/preprocess.py#L17):

```
return encode_midi(path, augumentation=False)
```

However, [the `encode_midi` function only accepts a single argument](https://github.com/jason9693/midi-neural-processor/blob/master/processor.py#L202):

```
def encode_midi(file_path):
```

I propose removing the argument, or alternatively, updating `encode_midi` to accept the second argument.